### PR TITLE
페이스북 로그인 & 관리자 등록 & Firebase SDK 최신 버전 & 회원 탈퇴 기능 추가

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,13 @@
             "program": "lib/main.dart"
         },
         {
+            "name": "iPhone11ProMax",
+            "request": "launch",
+            "type": "dart",
+            "deviceId": "iPhone11ProMax",
+            "program": "lib/main.dart"
+        },
+        {
             "name": "Simulator",
             "request": "launch",
             "type": "dart",

--- a/lib/screens/SettingPage.dart
+++ b/lib/screens/SettingPage.dart
@@ -1,4 +1,5 @@
 import 'package:blueberry_flutter_template/screens/OssLicensesScreen.dart';
+import 'package:easy_engine/easy_engine.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/NotificationProvider.dart';
@@ -66,6 +67,10 @@ class SettingPage extends ConsumerWidget {
               ),
               onPressed: () {},
               child: const Text('Account delete'),
+            ),
+            const SizedBox(height: 40),
+            const ClaimAdminButton(
+              region: 'asia-northeast3',
             ),
             const SizedBox(height: 40),
             SwitchListTile(

--- a/lib/screens/mypage/LoginScreen.dart
+++ b/lib/screens/mypage/LoginScreen.dart
@@ -208,7 +208,8 @@ Widget _buildLogin(BuildContext context, WidgetRef ref) {
               // Create a credential from the access token
               final OAuthCredential facebookAuthCredential =
                   FacebookAuthProvider.credential(
-                      loginResult.accessToken!.token);
+                loginResult.accessToken!.token,
+              );
 
               // Once signed in, return the UserCredential
               FirebaseAuth.instance

--- a/lib/screens/mypage/LoginScreen.dart
+++ b/lib/screens/mypage/LoginScreen.dart
@@ -1,4 +1,6 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/camera/page_provider.dart';
@@ -38,10 +40,10 @@ class LoginScreen extends ConsumerWidget {
         data: (user) => user != null
             ? PageView(
                 controller: pageState.pageController,
-                physics: NeverScrollableScrollPhysics(),
+                physics: const NeverScrollableScrollPhysics(),
                 children: [
-                    MyPageScreen(),
-                    ProfileCameraPage(),
+                    const MyPageScreen(),
+                    const ProfileCameraPage(),
                     ProfileGalleryPage(),
                   ])
             : _buildLogin(context, ref),
@@ -100,7 +102,7 @@ Widget _buildLogin(BuildContext context, WidgetRef ref) {
             },
           ),
 
-          SizedBox(height: 5),
+          const SizedBox(height: 5),
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
@@ -132,7 +134,7 @@ Widget _buildLogin(BuildContext context, WidgetRef ref) {
                         context: context,
                         builder: (BuildContext context) {
                           return AlertDialog(
-                            title: Text(AppStrings.errorTitle),
+                            title: const Text(AppStrings.errorTitle),
                             content: Text('에러: $e'),
                             actions: [
                               TextButton(
@@ -157,7 +159,7 @@ Widget _buildLogin(BuildContext context, WidgetRef ref) {
                   context,
                   MaterialPageRoute(builder: (context) => const SignUpScreen()),
                 ),
-                child: Text(
+                child: const Text(
                   AppStrings.signUpButtonText,
                   style: TextStyle(color: Colors.blue),
                 ),
@@ -196,6 +198,23 @@ Widget _buildLogin(BuildContext context, WidgetRef ref) {
                   onTap: () => AuthService().signInWithGithub(),
                   imagePath: 'assets/login_page_images/github.png'),
             ],
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              // Trigger the sign-in flow
+              final LoginResult loginResult =
+                  await FacebookAuth.instance.login();
+
+              // Create a credential from the access token
+              final OAuthCredential facebookAuthCredential =
+                  FacebookAuthProvider.credential(
+                      loginResult.accessToken!.token);
+
+              // Once signed in, return the UserCredential
+              FirebaseAuth.instance
+                  .signInWithCredential(facebookAuthCredential);
+            },
+            child: const Text('Facebook Login'),
           ),
         ],
       ),

--- a/lib/screens/mypage/MyPageScreen.dart
+++ b/lib/screens/mypage/MyPageScreen.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:blueberry_flutter_template/screens/mypage/camera/setting_inside_account_manager.dart';
 import 'package:blueberry_flutter_template/screens/mypage/camera/setting_inside_camera_media.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:easy_engine/easy_engine.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -50,14 +52,14 @@ class MyPageScreen extends ConsumerWidget {
                 )
               ],
             ),
-            SizedBox(
+            const SizedBox(
               height: 40,
             ),
             const CustomDivider(),
             GestureDetector(
               onTap: () {
                 Navigator.of(context).push(MaterialPageRoute(
-                  builder: (context) => FixSettingAccountManager(),
+                  builder: (context) => const FixSettingAccountManager(),
                 ));
               },
               child: const Expanded(
@@ -121,7 +123,7 @@ class MyPageScreen extends ConsumerWidget {
             GestureDetector(
               onTap: () {
                 Navigator.of(context).push(MaterialPageRoute(
-                  builder: (context) => FixSettingCameraMediaPage(),
+                  builder: (context) => const FixSettingCameraMediaPage(),
                 ));
               },
               child: const Expanded(
@@ -140,7 +142,7 @@ class MyPageScreen extends ConsumerWidget {
             GestureDetector(
               onTap: () {
                 Navigator.push(context, MaterialPageRoute(builder: (context) {
-                  return SettingPage();
+                  return const SettingPage();
                 }));
               },
               child: const Expanded(
@@ -164,6 +166,37 @@ class MyPageScreen extends ConsumerWidget {
                 leading: Icon(Icons.logout),
                 title: Text(
                   "로그아웃",
+                  style: TextStyle(fontSize: 20),
+                ),
+              )),
+            ),
+
+            //Logout button
+            GestureDetector(
+              onTap: () async {
+                try {
+                  final re = await engine.deleteAccount();
+                  print(re);
+                } on FirebaseFunctionsException catch (e) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text('Error: ${e.code}/${e.message}'),
+                    ),
+                  );
+                } catch (e) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                          'Error: $e'), // e.code: internal, e.message: INTERNAL
+                    ),
+                  );
+                }
+              },
+              child: const Expanded(
+                  child: ListTile(
+                leading: Icon(Icons.person_off),
+                title: Text(
+                  "회원탈퇴",
                   style: TextStyle(fontSize: 20),
                 ),
               )),
@@ -215,7 +248,7 @@ class MyPageScreen extends ConsumerWidget {
                         builder: (context) {
                           return Padding(
                             padding: MediaQuery.of(context).viewInsets,
-                            child: Container(
+                            child: SizedBox(
                               height: 150,
                               child: SettingsBottomSheet(),
                             ),
@@ -232,7 +265,7 @@ class MyPageScreen extends ConsumerWidget {
 
 Widget _uploadProfileImageButtons(FirestoreService firestoreService,
     FirebaseStorageService firebaseStorageService, BuildContext context) {
-  final _userId = FirebaseAuth.instance.currentUser!.uid;
+  final userId = FirebaseAuth.instance.currentUser!.uid;
 
   return IconButton(
       onPressed: () async {
@@ -240,16 +273,16 @@ Widget _uploadProfileImageButtons(FirestoreService firestoreService,
           var imageUrl = '';
 
           if (kIsWeb) {
-            final ImagePicker _picker = ImagePicker();
+            final ImagePicker picker = ImagePicker();
             final XFile? image =
-                await _picker.pickImage(source: ImageSource.gallery);
+                await picker.pickImage(source: ImageSource.gallery);
 
             image?.readAsBytes().then((value) async {
               imageUrl = await firebaseStorageService.uploadImageFromWeb(
                   value, ImageType.profileimage,
-                  fixedFileName: _userId);
+                  fixedFileName: userId);
 
-              firestoreService.createProfileIamge(_userId, imageUrl);
+              firestoreService.createProfileIamge(userId, imageUrl);
             });
           }
           if (!kIsWeb) {
@@ -259,9 +292,9 @@ Widget _uploadProfileImageButtons(FirestoreService firestoreService,
               // 선택된 이미지를 Firebase Storage에 업로드
               imageUrl = await firebaseStorageService.uploadImageFromApp(
                   File(pickedFile.path), ImageType.profileimage,
-                  fixedFileName: _userId);
+                  fixedFileName: userId);
 
-              firestoreService.createProfileIamge(_userId, imageUrl);
+              firestoreService.createProfileIamge(userId, imageUrl);
             }
           }
           if (imageUrl != '') {
@@ -271,5 +304,5 @@ Widget _uploadProfileImageButtons(FirestoreService firestoreService,
           }
         } catch (e) {}
       },
-      icon: Icon(Icons.settings));
+      icon: const Icon(Icons.settings));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: blueberry_flutter_template
 description: "flutter-template"
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.3.1 <4.0.0'
+  sdk: ">=3.3.1 <4.0.0"
 
 dependencies:
   flutter:
@@ -26,11 +26,11 @@ dependencies:
   json_annotation: ^4.9.0
 
   # Firebase
-  firebase_auth: ^4.19.2
-  firebase_core: ^2.32.0
-  firebase_storage: ^11.7.4
-  firebase_analytics: ^10.10.6
-  cloud_firestore: ^4.17.2
+  firebase_auth: ^5.1.1
+  firebase_core: ^3.1.1
+  firebase_storage: ^12.1.0
+  firebase_analytics: ^11.1.0
+  cloud_firestore: ^5.0.2
 
   # UI
   cupertino_icons: ^1.0.6
@@ -63,9 +63,10 @@ dependencies:
 
   # FCM
   permission_handler: ^11.3.1
-  firebase_messaging: ^14.9.4
+  firebase_messaging: 15.0.2
   flutter_local_notifications: ^17.2.1
   flutter_secure_storage: ^4.2.1
+  easy_engine: ^0.0.2
 
 dev_dependencies:
   flutter_test:
@@ -76,7 +77,6 @@ dev_dependencies:
   json_serializable: ^6.8.0
 
 flutter:
-
   uses-material-design: true
   assets:
     - assets/
@@ -85,7 +85,6 @@ flutter:
     - assets/700x150/
     - assets/logo/
     - assets/login_page_images/
-
 
 # Run Commands to generate splash screen
 # 1) flutter clean

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,7 @@ dependencies:
   flutter_local_notifications: ^17.2.1
   flutter_secure_storage: ^4.2.1
   easy_engine: ^0.0.3
+  flutter_facebook_auth: ^6.0.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   firebase_storage: ^12.1.0
   firebase_analytics: ^11.1.0
   cloud_firestore: ^5.0.2
+  cloud_functions: ^5.0.2
 
   # UI
   cupertino_icons: ^1.0.6
@@ -66,7 +67,7 @@ dependencies:
   firebase_messaging: 15.0.2
   flutter_local_notifications: ^17.2.1
   flutter_secure_storage: ^4.2.1
-  easy_engine: ^0.0.3
+  easy_engine: ^0.0.4
   flutter_facebook_auth: ^6.0.4
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,7 +66,7 @@ dependencies:
   firebase_messaging: 15.0.2
   flutter_local_notifications: ^17.2.1
   flutter_secure_storage: ^4.2.1
-  easy_engine: ^0.0.2
+  easy_engine: ^0.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 설명
- 설정에 관리자 등록 버튼 추가
- 비교적 최신 버전은 Firebase SDK 로 업데이트.
- 회원 가입 기능이 있으면 반드시 회원 탈퇴 기능이 있어야하며, 그렇지 않으면 앱이 리젝됩니다.
  - 참고: 애플 개발자 공식 홈페이지: https://developer.apple.com/support/offering-account-deletion-in-your-app/
`Starting June 30, 2022, apps submitted to the App Store that support account creation must also let users initiate deletion of their account within the app.`
  - 이메일 로그인을 하는 경우, Firebase Auth 에서 삭제를 하지 않으면, 다음 로그인(가입)을 하는 경우, 이전에 탈퇴할 때 본인의 계정이 삭제되지 않았다는 것을 알 수 있어서, Firebase Auth 에서도 계정을 삭제해야 합니다.
  - 계정 삭제를 위해서 플러터앱에서는 recent-login 을 처리해야하는데, 로그인 방법이 이메일, 전화, 소셜 로그인 등 많아 질 수록 각각 로직을 추가 해 주어야 합니다. 이것은 사용자에게 매우 불편한 것이며, 개발자도 로직을 많이 추가하고 관리해야하는 번거로움이 있습니다.
  - 이런 번거로움을 막고자, `deleteAccount` 라는 OnCall 클라우드 함수를 추가했습니다.



## 변경 사항
- pubspec.yaml 에 easy_engine 패키지 추가

## 체크리스트
< 체크리스트 항목을 확인해 주세요. >

- [x] 오늘도 행복하게 코딩했는가?
- [x] release 브랜치를 제대로 최신화 하고 이 브랜치에 merge 했는가?
- [x] PR 제목은 명확하고 간결한가?
- [x] PR 에는 하나의 작업에 대한 내용만 포함되었는가?
- [x] 파일명은 누구나 이해할 수 있게 작성되었는가?
- [x] camelCase를 사용하였는가? (ThisIsCamelCase, this_is_not_camel_case)
- [x] 텍스트는 AppStrings.dart 파일에서 가져오고 있는가?
- [x] 디스코드 채팅방에 완료된 태스크를 알렸는가?

## 스크린샷
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/85b266e1-610c-47e2-afbf-1326df8d06b2">


## 참조

최초 1명(선착순 1명) 관리자 등록은 Security Rules 만으로 안전하게 할 수 있지만, 이후 작업이 번거로워지는 DB 설계가 됩니다.
그래서 Cloud functions 로 관리자 등록을 할 수 있도록 했습니다.

아래는 지금 제가 작업하고 있는 범용 Firebase 프로젝트입니다. Firebase 쓰는 모든 웹/앱에서 쓸 수 있도록 작업을 하고 있습니다.
Easy Engine : https://github.com/thruthesky/easy-engine
