### PR TITLE
매칭 화면 provider 연결

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 // CI Test 환경에서는 Firebase 초기화를 하지 않음
-import 'firebase_options.dart' if (dart.library.io) 'firebase_options_ci.dart';
+import 'firebase_options.dart';
 
 import 'modules/core/notification/firebase_cloud_messaging_manager.dart';
 import 'modules/core/providers/ThemeProvider.dart';

--- a/lib/modules/core/views/home/TopPage.dart
+++ b/lib/modules/core/views/home/TopPage.dart
@@ -1,3 +1,4 @@
+import 'package:blueberry_flutter_template/modules/core/views/match/MatchPage.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -23,6 +24,7 @@ class TopPage extends ConsumerWidget {
     final selectedIndex = ref.watch(selectedIndexProvider);
 
     final List<Widget> pages = [
+      MatchPage(),
       ChatPage(),
       AdminPage(),
       LoginPage(),
@@ -39,6 +41,10 @@ class TopPage extends ConsumerWidget {
         unselectedIconTheme: const IconThemeData(color: Colors.grey),
         backgroundColor: Colors.blueGrey[100],
         items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.pets),
+            label: 'match',
+          ),
           BottomNavigationBarItem(
             icon: Icon(Icons.messenger_outline),
             label: 'chat',

--- a/lib/modules/core/views/match/MatchPage.dart
+++ b/lib/modules/core/views/match/MatchPage.dart
@@ -1,0 +1,76 @@
+import 'package:blueberry_flutter_template/modules/core/views/match/widget/SwiperCard.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_card_swiper/flutter_card_swiper.dart';
+
+import 'ProfilePage.dart';
+import 'model/DogProfileModel.dart';
+
+///  MatchPage - 프로필 스와이프 매칭 화면
+///
+///  주요 구성 요소:
+///  - CardSwiper: 프로필 카드를 스와이프할 수 있는 메인 위젯
+///  - FloatingActionButton: 수동으로 좌/우 스와이프를 할 수 있는 버튼
+
+class MatchPage extends StatefulWidget {
+  const MatchPage({super.key});
+
+  @override
+  State<MatchPage> createState() => _MatchPageState();
+}
+
+class _MatchPageState extends State<MatchPage> {
+  final CardSwiperController controller = CardSwiperController();
+  final cards = dogProfiles.map(SwiperCard.new).toList();
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Flexible(
+              child: CardSwiper(
+                controller: controller,
+                cardsCount: cards.length,
+                onSwipe: _onSwipe,
+                cardBuilder: (context, index, horizontalThresholdPercentage, verticalThresholdPercentage,) => cards[index],
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                FloatingActionButton(
+                  heroTag: '0',
+                  onPressed: () => controller.swipe(CardSwiperDirection.left),
+                  child: const Icon(Icons.close),
+                ),
+                FloatingActionButton(
+                  heroTag: '1',
+                  onPressed: () => controller.swipe(CardSwiperDirection.right),
+                  child: const Icon(Icons.check),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  bool _onSwipe(int previousIndex, int? currentIndex, CardSwiperDirection direction) {
+    if (direction == CardSwiperDirection.right) {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => ProfilePage(dogProfile: dogProfiles[previousIndex]),
+        ),
+      );
+    }
+    return true;
+  }
+}

--- a/lib/modules/core/views/match/ProfilePage.dart
+++ b/lib/modules/core/views/match/ProfilePage.dart
@@ -1,0 +1,52 @@
+import 'package:blueberry_flutter_template/modules/core/views/match/model/DogProfileModel.dart';
+import 'package:flutter/material.dart';
+
+class ProfilePage extends StatelessWidget {
+  final DogProfileModel dogProfile;
+
+  const ProfilePage({super.key, required this.dogProfile});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(dogProfile.name),
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Image.network(
+              dogProfile.imageUrl,
+              width: double.infinity,
+              height: 300,
+              fit: BoxFit.cover,
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    dogProfile.name,
+                    style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                  ),
+                  SizedBox(height: 8),
+                  Text('성별: ${dogProfile.gender}'),
+                  Text('종족: ${dogProfile.breed}'),
+                  Text('사는 곳: ${dogProfile.location}'),
+                  SizedBox(height: 16),
+                  Text(
+                    '소개',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  Text(dogProfile.bio),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/core/views/match/model/DogProfileModel.dart
+++ b/lib/modules/core/views/match/model/DogProfileModel.dart
@@ -1,0 +1,44 @@
+class DogProfileModel {
+  final String name;
+  final String gender;
+  final String breed;
+  final String bio;
+  final String imageUrl;
+  final String location;
+
+  DogProfileModel({
+    required this.name,
+    required this.gender,
+    required this.breed,
+    required this.bio,
+    required this.imageUrl,
+    required this.location,
+  });
+}
+
+final List<DogProfileModel> dogProfiles = [
+  DogProfileModel(
+    name: '멍멍이',
+    gender: '수컷',
+    breed: '골든 리트리버',
+    location: '서울',
+    bio: '산책을 좋아하는 활발한 강아지예요!',
+    imageUrl: 'https://img1.daumcdn.net/thumb/R800x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FcY8RCd%2FbtsC31gfzPL%2FbSnADONPu66xPesaWHmW00%2Fimg.jpg',
+  ),
+  DogProfileModel(
+    name: '뭉치',
+    gender: '암컷',
+    breed: '푸들',
+    location: '부산',
+    bio: '애교 많고 사랑스러운 강아지입니다.',
+    imageUrl: 'https://image.dongascience.com/Photo/2017/07/14994185580021.jpg',
+  ),
+  DogProfileModel(
+    name: '초코',
+    gender: '수컷',
+    breed: '비글',
+    location: '대구',
+    bio: '장난기 많고 활발한 성격이에요.',
+    imageUrl: 'https://cdn.newscj.com/news/photo/201309/170126_122268_2013.jpg',
+  ),
+];

--- a/lib/modules/core/views/match/widget/SwiperCard.dart
+++ b/lib/modules/core/views/match/widget/SwiperCard.dart
@@ -1,0 +1,77 @@
+import 'package:blueberry_flutter_template/modules/core/views/match/model/DogProfileModel.dart';
+import 'package:flutter/material.dart';
+
+class SwiperCard extends StatelessWidget {
+  final DogProfileModel dogProfiles;
+
+  const SwiperCard(
+      this.dogProfiles, {
+        super.key,
+      });
+
+  @override
+  Widget build(BuildContext context) {
+    double height = MediaQuery.of(context).size.height;
+    double width = MediaQuery.of(context).size.width;
+
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(10),
+      ),
+      elevation: 5,
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(10),
+          image: DecorationImage(
+            image: NetworkImage(dogProfiles.imageUrl),
+            fit: BoxFit.cover,
+          ),
+        ),
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(10),
+            gradient: LinearGradient(
+              begin: Alignment.bottomCenter,
+              end: Alignment.topCenter,
+              colors: [Colors.black.withOpacity(0.8), Colors.transparent],
+            ),
+          ),
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: height * 0.03, horizontal: width * 0.05),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      dogProfiles.name,
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    SizedBox(width: width * 0.02),
+                    Text(
+                      '${dogProfiles.gender} • ${dogProfiles.breed} • ${dogProfiles.location}',
+                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                        color: Colors.white70,
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: height * 0.005),
+                Text(
+                  dogProfiles.bio,
+                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: Colors.white70,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,9 @@ dependencies:
   transparent_image: ^2.0.1
   photo_manager_image_provider: ^2.1.1
 
+  # Match
+  flutter_card_swiper: ^7.0.1
+
   # FCM
   permission_handler: ^11.3.1
   firebase_messaging: ^14.9.4


### PR DESCRIPTION
## 설명
초기 데이터 세팅을 위한 Provider 연결

## 변경 사항

- MatchProvider.dart 생성: 임시로 'dogProfiles'에서 데이터를 가져오는 로직으로 짰습니다.
- MatchScreen.dart 수정: 데이터가 없을 시 'No profiles found'를 화면에 띄우도록 하였습니다.

## 체크리스트
< 체크리스트 항목을 확인해 주세요. >

- [x] 오늘도 행복하게 코딩했는가?
- [x] release 브랜치를 제대로 최신화 하고 이 브랜치에 merge 했는가?
- [x] PR 제목은 명확하고 간결한가?
- [x] PR 에는 하나의 작업에 대한 내용만 포함되었는가?
- [x] 파일명은 누구나 이해할 수 있게 작성되었는가?
- [x] camelCase를 사용하였는가? (ThisIsCamelCase, this_is_not_camel_case)
- [x] 텍스트는 AppStrings.dart 파일에서 가져오고 있는가?
- [ ] 디스코드 채팅방에 완료된 태스크를 알렸는가?

## 스크린샷
<img width="462" alt="image" src="https://github.com/user-attachments/assets/9f7b5e71-8903-4225-9b02-6bd3bf881c21">

## 참조

관련된 이슈나 PR이 있다면 링크를 추가해주세요.
